### PR TITLE
Add support for using glob patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,17 @@ database:
    user: ${PROD_DB_USER}
    logValidationErrors: false
 ```
+
+The `import` directive also supports the `glob` syntax accepted by [FileSystem#getPathMatcher](https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)):
+
+`config.yml`:
+
+``` yml
+imports:
+   - path/to/childs/**/*.yml
+```
+
 ## TODO
 
  - [ ] Circular reference detection
- - [ ] Support for other than local file resource types
+ - [ ] Support for other than local file resource types (S3)

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,10 @@ uploadArchives {
                         id 'vvondra'
                         name 'Vojtěch Vondra'
                     }
+                    developer {
+                        id 'aelesbao'
+                        name 'Augusto Elesbão'
+                    }
                 }
             }
         }

--- a/src/main/java/com/foodpanda/dropwizard/configuration/ImportableConfigurationFactoryFactory.java
+++ b/src/main/java/com/foodpanda/dropwizard/configuration/ImportableConfigurationFactoryFactory.java
@@ -7,6 +7,7 @@ import javax.validation.Validator;
 import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
 
+@SuppressWarnings("unused")
 public class ImportableConfigurationFactoryFactory<T> extends DefaultConfigurationFactoryFactory<T> {
     @Override
     public ConfigurationFactory<T> create(

--- a/src/test/java/com/foodpanda/dropwizard/configuration/ImportableConfigurationFactoryTest.java
+++ b/src/test/java/com/foodpanda/dropwizard/configuration/ImportableConfigurationFactoryTest.java
@@ -43,6 +43,15 @@ public class ImportableConfigurationFactoryTest {
         }
     }
 
+    public static class GlobExample {
+        @JsonProperty
+        private Map<String, LinkedHashMap<String, String>> properties = new LinkedHashMap<>();
+
+        public Map<String, LinkedHashMap<String, String>> getProperties() {
+            return properties;
+        }
+    }
+
 
     @After
     public void resetConfigOverrides() {
@@ -71,6 +80,22 @@ public class ImportableConfigurationFactoryTest {
         assertFalse(Boolean.valueOf(example.getProperties().get("debug")));
         assertEquals("foo", example.getProperties().get("extra"));
         assertEquals("bar", example.getProperties().get("extended"));
+    }
+
+    @Test
+    public void importGlobConfigurationFile() throws Exception {
+        final ConfigurationFactory<GlobExample> factory = createFactory(GlobExample.class);
+
+        final File importingGlobFile = resourceFileName("factory-test-importing-glob.yml");
+        final GlobExample example = factory.build(importingGlobFile);
+
+        assertTrue(example.getProperties().containsKey("a"));
+        assertEquals("Complex Sample A", example.getProperties().get("a").get("name"));
+        assertTrue(Boolean.valueOf(example.getProperties().get("a").get("debug")));
+
+        assertTrue(example.getProperties().containsKey("b"));
+        assertEquals("Complex Sample B", example.getProperties().get("b").get("name"));
+        assertFalse(Boolean.valueOf(example.getProperties().get("b").get("debug")));
     }
 
     private static File resourceFileName(String resourceName) throws URISyntaxException {

--- a/src/test/resources/complex/a/factory-test-glob.yml
+++ b/src/test/resources/complex/a/factory-test-glob.yml
@@ -1,0 +1,4 @@
+properties:
+  a:
+    name: "Complex Sample A"
+    debug: "false"

--- a/src/test/resources/complex/b/factory-test-glob.yml
+++ b/src/test/resources/complex/b/factory-test-glob.yml
@@ -1,0 +1,4 @@
+properties:
+  b:
+    name: "Complex Sample B"
+    debug: "false"

--- a/src/test/resources/factory-test-importing-glob.yml
+++ b/src/test/resources/factory-test-importing-glob.yml
@@ -1,0 +1,6 @@
+imports:
+ - complex/**/*.yml
+
+properties:
+  a:
+    debug: "true"


### PR DESCRIPTION
With this, it is now possible to import configuration files using `**/*.yml`, which is useful for complex setups.